### PR TITLE
Fix pre commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,1 @@
-pnpm format
-pnpm lint
+pnpm lint-staged

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "license": "MIT",
     "author": "Louis Brann, Eric Warren",
     "main": "content-script.js",
-    "packageManager": "pnpm@9.12.1",
     "scripts": {
         "dev": "wxt",
         "dev:firefox": "wxt -b firefox",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "license": "MIT",
     "author": "Louis Brann, Eric Warren",
     "main": "content-script.js",
+    "packageManager": "pnpm@9.12.1",
     "scripts": {
         "dev": "wxt",
         "dev:firefox": "wxt -b firefox",
@@ -55,11 +56,11 @@
     },
     "lint-staged": {
         "*.{js,ts}": [
-            "prettier --write",
-            "eslint --fix"
+            "prettier",
+            "eslint"
         ],
         "!(*.js|*.ts)": [
-            "prettier --write"
+            "prettier"
         ]
     }
 }

--- a/package.json
+++ b/package.json
@@ -54,11 +54,11 @@
         "wxt": "0.19.29"
     },
     "lint-staged": {
-        "*.{js,ts}": [
+        "*.{js,ts,jsx,tsx}": [
             "prettier",
             "eslint"
         ],
-        "!(*.js|*.ts)": [
+        "!(*.js|*.ts|*.jsx|*.tsx)": [
             "prettier"
         ]
     }


### PR DESCRIPTION
addresses #1

## Motivation
Pre-commit hook was annoying

it was formatting with editing, not just the files that were staged for commit, but all files

## Solution
1. Use `lint-staged` in the husky pre-commit hook
2. Update the `lint-staged` config to not use `--write`/`--fix` flags